### PR TITLE
Remove references to non-existent *-common packages

### DIFF
--- a/packages.x86_64
+++ b/packages.x86_64
@@ -1,4 +1,2 @@
 spl-linux
-spl-utils-common
 zfs-linux
-zfs-utils-common


### PR DESCRIPTION
The script currently fails as it references packages that no longer exist. Simply removing said packages results in a functional ISO.